### PR TITLE
feat: normalize RAG summary sections

### DIFF
--- a/un.py
+++ b/un.py
@@ -374,6 +374,19 @@ class RAG:
              {"role": "user",   "content": ctx[:20_000]}],
             model=self.llm_model, T=0.25)
 
+    def _normalize_sections(self, summary: str) -> str:
+        sections = summary.split("\n\n")
+        norm = []
+        for sec in sections:
+            lines = [l.strip() for l in sec.splitlines() if l.strip()]
+            seen, uniq = set(), []
+            for line in lines:
+                if line not in seen:
+                    seen.add(line)
+                    uniq.append(line)
+            norm.append("\n".join(uniq) if uniq else "не найдено")
+        return "\n\n".join(norm)
+
     # ---------- orchestrator -------------------------------------------
     async def _run_async(self):
         # paralell: сниппет + детальный паспорт сайта
@@ -434,6 +447,7 @@ class RAG:
 
         # ---------- финальный отчёт ----------------------------------
         summary = await self._summary("\n\n".join(ctx_parts))
+        summary = self._normalize_sections(summary)
 
         return {
             "summary":     summary,


### PR DESCRIPTION
## Summary
- add `_normalize_sections` helper that removes duplicate lines in each summary section and fills empty sections with `не найдено`
- call helper after `RAG._summary` so orchestrator returns cleaned summary

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b564b209208324bb7a1ce66f94619b