### PR TITLE
Round leader share percentages to one decimal

### DIFF
--- a/test_people.py
+++ b/test_people.py
@@ -1,0 +1,16 @@
+import importlib
+import streamlit as st
+
+
+def test_extract_people_rounds_share(monkeypatch):
+    monkeypatch.setattr(st, "secrets", {
+        "OPENAI_API_KEY": "x",
+        "GOOGLE_API_KEY": "x",
+        "GOOGLE_CX": "x",
+        "CHECKO_API_KEY": "x",
+        "DYXLESS_TOKEN": "x",
+    })
+    un = importlib.import_module("un")
+    cell = [{"ФИО": "Иван", "ИНН": "123", "Доля": {"Процент": 12.34}}]
+    assert un.extract_people(cell) == ["Иван (ИНН 123, доля 12.3%)"]
+

--- a/un.py
+++ b/un.py
@@ -1006,7 +1006,7 @@ def extract_people(cell) -> list[str]:
                 if inn:
                     line += f" (ИНН {inn}"
                     if share is not None:
-                        line += f", доля {share}%)"
+                        line += f", доля {float(share):.1f}%)"
                     else:
                         line += ")"
                 people.append(line)
@@ -1168,7 +1168,10 @@ def run_ai_insight_tab() -> None:
                             line  = fio
                             if inn:
                                 line += f" (ИНН {inn}"
-                                line += f", доля {int(share)}%)" if share is not None else ")"
+                                if share is not None:
+                                    line += f", доля {float(share):.1f}%)"
+                                else:
+                                    line += ")"
                             out.append(line)
                     return [s for s in out if s]
                 # fallback


### PR DESCRIPTION
## Summary
- Format share percentages with one decimal in leader parsing
- Add regression test for share rounding

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b818e8faa483248d16ea0d2f65ddae