### PR TITLE
Include leader photos with placeholder fallback

### DIFF
--- a/test_leaders.py
+++ b/test_leaders.py
@@ -1,5 +1,20 @@
 import importlib, asyncio, aiohttp, streamlit as st
 
+async def fake_google(sess, q, n=3):
+    return [("https://kommersant.ru/test", "snippet"), ("https://example.com", "other")]
+
+async def fake_gpt(messages, **kwargs):
+    return "career; legal; assets; net worth"
+
+async def fake_image(sess, q):
+    return "https://img.com/pic.jpg"
+
+async def fake_interviews(self, names, sess):
+    return [], [], ""
+
+async def no_image(sess, q):
+    return ""
+
 def test_leaders_bio_and_news(monkeypatch):
     monkeypatch.setattr(st, "secrets", {
         "OPENAI_API_KEY": "x",
@@ -9,16 +24,6 @@ def test_leaders_bio_and_news(monkeypatch):
         "DYXLESS_TOKEN": "x",
     })
     un = importlib.import_module("un")
-
-    async def fake_google(sess, q, n=3):
-        return [("https://kommersant.ru/test", "snippet"), ("https://example.com", "other")]
-
-    async def fake_gpt(messages, **kwargs):
-        return "career; legal; assets; net worth"
-
-    async def fake_image(sess, q):
-        return "https://img.com/pic.jpg"
-
     monkeypatch.setattr(un, "_google", fake_google)
     monkeypatch.setattr(un, "_gpt", fake_gpt)
     monkeypatch.setattr(un, "_image", fake_image)
@@ -42,3 +47,28 @@ def test_leaders_bio_and_news(monkeypatch):
     assert people[0]["bio"] == "career; legal; assets; net worth"
     assert people[0]["news"] == ["https://kommersant.ru/test"]
     assert people[0]["photo"] == "https://img.com/pic.jpg"
+
+
+def test_report_includes_photo_or_placeholder(monkeypatch):
+    monkeypatch.setattr(st, "secrets", {
+        "OPENAI_API_KEY": "x",
+        "GOOGLE_API_KEY": "x",
+        "GOOGLE_CX": "x",
+        "CHECKO_API_KEY": "x",
+        "DYXLESS_TOKEN": "x",
+    })
+    un = importlib.import_module("un")
+    monkeypatch.setattr(un, "_google", fake_google)
+    monkeypatch.setattr(un, "_gpt", fake_gpt)
+    monkeypatch.setattr(un.FastLeadersInterviews, "_interviews", fake_interviews)
+    cinfo = {"leaders_raw": un.extract_people([{ "ФИО": "Иванов Иван" }])}
+
+    monkeypatch.setattr(un, "_image", fake_image)
+    rag = un.FastLeadersInterviews("Comp", company_info=cinfo)
+    res = rag.run()
+    assert 'href="https://img.com/pic.jpg"' in res["summary"]
+
+    monkeypatch.setattr(un, "_image", no_image)
+    rag = un.FastLeadersInterviews("Comp", company_info=cinfo)
+    res = rag.run()
+    assert "Фото: изображение не найдено" in res["summary"]

--- a/un.py
+++ b/un.py
@@ -881,8 +881,11 @@ class FastLeadersInterviews:
                     block += f"\n{p['bio']}"
                 if p.get("news"):
                     block += "\nНовости о владельцах:\n" + "\n".join(p["news"])
-                if p.get("photo"):
-                    block += f"\nФото: {p['photo']}"
+                photo = p.get("photo")
+                if photo:
+                    block += f"\nФото: {photo}"
+                else:
+                    block += "\nФото: изображение не найдено"
                 blocks.append(block)
             owners_block = "\n\n".join(blocks)
         else:


### PR DESCRIPTION
## Summary
- Always show a photo line for each leader, using a Google image URL when available or an "изображение не найдено" placeholder otherwise【F:un.py†L882-L888】
- Add tests ensuring the summary renders the image link or placeholder appropriately【F:test_leaders.py†L52-L74】

## Testing
- `pytest -q`【9b89e3†L1-L2】

------
https://chatgpt.com/codex/tasks/task_e_68b819062f1483249cb25846d2f55c71